### PR TITLE
Restore Option Display iOS Example

### DIFF
--- a/example/Example.ios.js
+++ b/example/Example.ios.js
@@ -64,10 +64,10 @@ class AutocompleteExample extends Component {
           defaultValue={query}
           onChangeText={text => this.setState({ query: text })}
           placeholder="Enter Star Wars film title"
-          renderItem={({ title }) => (
-            <TouchableOpacity onPress={() => this.setState({ query: title })}>
+          renderItem={({ item, i }) => (
+            <TouchableOpacity onPress={() => this.setState({ query: item.title })}>
               <Text style={styles.itemText}>
-                {title}
+                {item.title}
               </Text>
             </TouchableOpacity>
           )}


### PR DESCRIPTION
The dropdown options weren't showing up for me (the dropdown would expand correctly based on number of autocomplete matches but there was no text visible), but this change (following the README) example fixed the issue.