### PR TITLE
Fix: touch interaction not working on android

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ export const AutocompleteInput = (props) => {
   function renderResultList(data, listProps) {
     const { style, ...flatListProps } = listProps;
 
-    return <FlatList data={data} style={[styles.list, style]} {...flatListProps} />;
+    return <View><FlatList data={data} style={[styles.list, style]} {...flatListProps} /></View>;
   }
 
   function renderTextInput() {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FlatList, Platform, StyleSheet, Text, TextInput, View, ViewPropTypes } from 'react-native';
+import { Platform, StyleSheet, Text, TextInput, View, ViewPropTypes } from 'react-native';
+import { FlatList } from "react-native-gesture-handler";
+
 
 export const AutocompleteInput = (props) => {
   function renderResultList(data, listProps) {


### PR DESCRIPTION
Importing FlatList from "react-native-gesture-handler" makes it compatible with both iOS and Android.