### PR TITLE
Add renderResultList prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ const styles = StyleSheet.create({
 | onStartShouldSetResponderCapture | function | `onStartShouldSetResponderCapture` will be passed to the result list view container ([onStartShouldSetResponderCapture](https://facebook.github.io/react-native/docs/gesture-responder-system.html#capture-shouldset-handlers)). |
 | renderTextInput | function | render custom TextInput. All props passed to this function. |
 | flatListProps | object | custom props to [FlatList](https://facebook.github.io/react-native/docs/flatlist.html). |
+| renderResultList | function | render custom result list. Can be used to replace FlatList. All props passed to this function. |
 
 ## Known issues
-* By default the autocomplete will not behave as expected inside a `<ScrollView />`. Set the scroll view's prop to fix this: `keyboardShouldPersistTaps={true}` for RN <= 0.39, or `keyboardShouldPersistTaps='always'` for RN >= 0.40. ([#5](https://github.com/mrlaessig/react-native-autocomplete-input/issues/5)).
+* By default the autocomplete will not behave as expected inside a `<ScrollView />`. Set the scroll view's prop to fix this: `keyboardShouldPersistTaps={true}` for RN <= 0.39, or `keyboardShouldPersistTaps='always'` for RN >= 0.40. ([#5](https://github.com/mrlaessig/react-native-autocomplete-input/issues/5)). Alternatively, you can use renderResultList to render a custom result list that does not use FlatList. See the tests for an example.
 * If you want to test with Jest add ```jest.mock('react-native-autocomplete-input', () => 'Autocomplete');``` to your test.
 
 ## Contribute

--- a/__tests__/AutocompleteInput.spec.js
+++ b/__tests__/AutocompleteInput.spec.js
@@ -82,7 +82,9 @@ describe('<AutocompleteInput />', () => {
   });
 
   it('should only pass props in flatListProps to <FlatList />', () => {
-    const flatListProps = { foo: 'bar' };
+    // Using keyExtractor isn't important for the test, but prevents a warning
+    const keyExtractor = (_, index) => `key-${index}`;
+    const flatListProps = { foo: 'bar', keyExtractor };
     const otherProps = { baz: 'qux' };
     const testRenderer = renderer.create(
       <Autocomplete data={ITEMS} flatListProps={flatListProps} {...otherProps} />

--- a/__tests__/AutocompleteInput.spec.js
+++ b/__tests__/AutocompleteInput.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { FlatList, Text, TextInput } from 'react-native';
+import { FlatList, Text, TextInput, View } from 'react-native';
 import Autocomplete from '..';
 
 const ITEMS = [
@@ -94,5 +94,28 @@ describe('<AutocompleteInput />', () => {
 
     expect(list.props).toEqual(expect.objectContaining(flatListProps));
     expect(list.props).toEqual(expect.not.objectContaining(otherProps));
+  });
+
+  it('should render a custom result list', () => {
+    const testRenderer = renderer.create(
+      <Autocomplete
+        data={ITEMS}
+        renderResultList={({ data, style }) => (
+          <View style={style}>
+            {data.map((item, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <Text key={index}>{item}</Text>
+            ))}
+          </View>
+        )}
+      />
+    );
+
+    const autocomplete = testRenderer.root;
+
+    expect(autocomplete.findAllByType(FlatList)).toHaveLength(0);
+
+    const texts = autocomplete.findAllByType(Text);
+    expect(texts).toHaveLength(ITEMS.length);
   });
 });

--- a/__tests__/AutocompleteInput.spec.js
+++ b/__tests__/AutocompleteInput.spec.js
@@ -72,4 +72,25 @@ describe('<AutocompleteInput />', () => {
 
     expect(textInput.props).toEqual(expect.objectContaining(props));
   });
+
+  it('should render default <FlatList /> if no custom one is supplied', () => {
+    const testRenderer = renderer.create(<Autocomplete data={ITEMS} />);
+    const autocomplete = testRenderer.root;
+    const list = autocomplete.findByType(FlatList);
+
+    expect(list.props.data).toEqual(ITEMS);
+  });
+
+  it('should only pass props in flatListProps to <FlatList />', () => {
+    const flatListProps = { foo: 'bar' };
+    const otherProps = { baz: 'qux' };
+    const testRenderer = renderer.create(
+      <Autocomplete data={ITEMS} flatListProps={flatListProps} {...otherProps} />
+    );
+    const autocomplete = testRenderer.root;
+    const list = autocomplete.findByType(FlatList);
+
+    expect(list.props).toEqual(expect.objectContaining(flatListProps));
+    expect(list.props).toEqual(expect.not.objectContaining(otherProps));
+  });
 });

--- a/index.js
+++ b/index.js
@@ -3,10 +3,14 @@ import PropTypes from 'prop-types';
 import { FlatList, Platform, StyleSheet, Text, TextInput, View, ViewPropTypes } from 'react-native';
 
 export const AutocompleteInput = (props) => {
-  function renderResultList(data, listProps) {
-    const { style, ...flatListProps } = listProps;
+  function renderResultList() {
+    const { renderResultList: renderFunction, style } = props;
+    const listProps = {
+      style: [styles.list, style],
+      ...props,
+    };
 
-    return <FlatList data={data} style={[styles.list, style]} {...flatListProps} />;
+    return renderFunction(listProps);
   }
 
   function renderTextInput() {
@@ -27,6 +31,8 @@ export const AutocompleteInput = (props) => {
     listContainerStyle,
     onShowResults,
     onStartShouldSetResponderCapture,
+    // flatListProps is only used in defaultResultList
+    // eslint-disable-next-line no-unused-vars
     flatListProps,
   } = props;
 
@@ -35,13 +41,13 @@ export const AutocompleteInput = (props) => {
   onShowResults && onShowResults(showResults);
   return (
     <View style={[styles.container, containerStyle]}>
-      <View style={[styles.inputContainer, inputContainerStyle]}>{renderTextInput(props)}</View>
+      <View style={[styles.inputContainer, inputContainerStyle]}>{renderTextInput()}</View>
       {!hideResults && (
         <View
           style={listContainerStyle}
           onStartShouldSetResponderCapture={onStartShouldSetResponderCapture}
         >
-          {showResults && renderResultList(data, flatListProps)}
+          {showResults && renderResultList()}
         </View>
       )}
     </View>
@@ -91,15 +97,22 @@ AutocompleteInput.propTypes = {
    * renders custom TextInput. All props passed to this function.
    */
   renderTextInput: PropTypes.func,
+  /**
+   * renders custom result list. Can be used to replace FlatList.
+   * All props passed to this function.
+   */
+  renderResultList: PropTypes.func,
 };
 
 const defaultKeyExtractor = (_, index) => `key-${index}`;
 const defaultRenderItem = ({ item }) => <Text>{item}</Text>;
+const defaultResultList = ({ data, flatListProps }) => <FlatList data={data} {...flatListProps} />;
 
 AutocompleteInput.defaultProps = {
   data: [],
   onStartShouldSetResponderCapture: () => false,
   renderTextInput: (props) => <TextInput {...props} />,
+  renderResultList: defaultResultList,
   flatListProps: {
     renderItem: defaultRenderItem,
     keyExtractor: defaultKeyExtractor,


### PR DESCRIPTION
This allows you to replace `<FlatList />` with another component. The motivation for this is to allow you to use `<Autocomplete />` inside of a `<ScrollView />` without getting that `VirtualizedLists should never be nested inside plain ScrollViews` error.

Fixes #219

I added unit tests, but I also manually tested using my own app. Here's the relevant part of my code so you can see how this would work in practice:

```js
import { useState } from "react";
import { Text, View, Pressable } from "react-native";
import Autocomplete from "react-native-autocomplete-input";

function MyAutocomplete() {
  const [search, setSearch] = useState("");
  const [selectedTag, setSelectedTag] = useState(null);
  const data = [{id: "example", value: "example"}];

  return (
     <Autocomplete
        value={search}
        onChangeText={(text) => {
          setSearch(text);
          setSelectedTag(null);
        }}
        data={[...tags, { id: "new", value: `Create new tag: ${search}` }]}
        renderResultList={({ data, style }) => (
          <View style={style}>
            {data.map(({ id, value }) => (
              <Pressable
                onPress={() => {
                  setSelectedTag(id);
                  if (id !== "new") {
                    setSearch(value);
                  }
                }}
                key={id}
              >
                <Text>{value}</Text>
              </Pressable>
            ))}
          </View>
        )}
        hideResults={search.length < 3}
        containerStyle={{ flexGrow: 1 }}
      />);
}
```